### PR TITLE
Fix PreKeys refresh timer and add handling for NoGroupFoundException

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.github.turakar:signal4j:1.0.3'
+    compile 'com.github.turakar:signal4j:1.0.4'
 }
 
 task fatJar(type: Jar) {


### PR DESCRIPTION
*a)* The PreKeys refresh timer was only started on fresh registrations, as it was wrongly placed in the if-statement before.

*b)* If the bot was added with an old registration to a group, this group is not saved in the store of signal4j. This can be fixed by catching the thrown NoGroupFoundException and manually entering the member's numbers. With re-adding the bot it will receive an update message containing all the relevant group information. That's handled automatically by signal4j.

(With the update of signal4j the signal library fork is switched from my one to one I share with AsamK which has the provisioning ability from my fork and a lot of bugfixes/improvements from AsamK's fork)